### PR TITLE
Fix use of UTF-8 characters to host in Uri class

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -22,6 +22,7 @@ use function preg_replace_callback;
 use function rawurlencode;
 use function sprintf;
 use function strtolower;
+use function strtr;
 
 final class Uri implements UriInterface
 {
@@ -406,7 +407,7 @@ final class Uri implements UriInterface
      */
     private function normalizeHost(string $host): string
     {
-        return strtolower($host);
+        return strtr($host, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz');
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -447,6 +447,21 @@ final class UriTest extends TestCase
         $uri = (new Uri())->withHost($host = '例子.例子');
         $this->assertSame($host, $uri->getHost());
         $this->assertSame('//' . $host, (string) $uri);
+
+        $uri = new Uri('https://ουτοπία.δπθ.gr/');
+        $this->assertSame('ουτοπία.δπθ.gr', $uri->getHost());
+        $new = $uri->withHost($host = '程式设计.com');
+        $this->assertSame($host, $new->getHost());
+
+        $uri = (new Uri())->withHost($host = 'παράδειγμα.δοκιμή');
+        $this->assertSame($host, $uri->getHost());
+        $this->assertSame('//' . $host, (string) $uri);
+
+        $uri = new Uri('https://яндекс.рф');
+        $this->assertSame('яндекс.рф', $uri->getHost());
+
+        $uri = new Uri('https://яндекAс.рф');
+        $this->assertSame('яндекaс.рф', $uri->getHost());
     }
 
     public function testPercentageEncodedWillNotBeReEncoded(): void

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -466,8 +466,11 @@ final class UriTest extends TestCase
 
     public function testPercentageEncodedWillNotBeReEncoded(): void
     {
-        $uri = new Uri('https://example.com/pa<th/to/tar>get/?qu^ery=str|ing#frag%ment');
-        $this->assertSame('https://example.com/pa%3Cth/to/tar%3Eget/?qu%5Eery=str%7Cing#frag%25ment', (string) $uri);
+        $uri = new Uri('https://us%40er:pa%23ss@example.com/pa<th/to/tar>get/?qu^ery=str|ing#frag%ment');
+        $this->assertSame(
+            'https://us%40er:pa%23ss@example.com/pa%3Cth/to/tar%3Eget/?qu%5Eery=str%7Cing#frag%25ment',
+            (string) $uri,
+        );
 
         $newUri = new Uri((string) $uri);
         $this->assertSame((string) $uri, (string) $newUri);
@@ -480,6 +483,18 @@ final class UriTest extends TestCase
 
         $uri = (new Uri('#' . $fragment = 'frag%3C%3Ement'))->withFragment($fragment);
         $this->assertSame($fragment, $uri->getFragment());
+    }
+
+    public function testIPv6Host(): void
+    {
+        $uri = new Uri('https://[2a00:f48:1008::212:183:10]');
+        $this->assertSame('[2a00:f48:1008::212:183:10]', $uri->getHost());
+
+        $uri = new Uri('https://[2a00:f48:1008::212:183:10]:56/path/to/target?key=value');
+        $this->assertSame('[2a00:f48:1008::212:183:10]', $uri->getHost());
+        $this->assertSame(56, $uri->getPort());
+        $this->assertSame('/path/to/target', $uri->getPath());
+        $this->assertSame('key=value', $uri->getQuery());
     }
 
     /**

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -444,23 +444,24 @@ final class UriTest extends TestCase
 
     public function testUtf8Host(): void
     {
-        $uri = (new Uri())->withHost($host = '例子.例子');
-        $this->assertSame($host, $uri->getHost());
-        $this->assertSame('//' . $host, (string) $uri);
-
         $uri = new Uri('https://ουτοπία.δπθ.gr/');
         $this->assertSame('ουτοπία.δπθ.gr', $uri->getHost());
         $new = $uri->withHost($host = '程式设计.com');
         $this->assertSame($host, $new->getHost());
 
+        $uri = (new Uri())->withHost($host = '例子.例子');
+        $this->assertSame($host, $uri->getHost());
+        $this->assertSame('//' . $host, (string) $uri);
+
         $uri = (new Uri())->withHost($host = 'παράδειγμα.δοκιμή');
         $this->assertSame($host, $uri->getHost());
         $this->assertSame('//' . $host, (string) $uri);
 
-        $uri = new Uri('https://яндекс.рф');
-        $this->assertSame('яндекс.рф', $uri->getHost());
+        $uri = (new Uri())->withHost($host = 'яндекс.рф');
+        $this->assertSame($host, $uri->getHost());
 
-        $uri = new Uri('https://яндекAс.рф');
+        // "A" is a Latin letter
+        $uri = (new Uri())->withHost('яндекAс.рф');
         $this->assertSame('яндекaс.рф', $uri->getHost());
     }
 

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -442,6 +442,27 @@ final class UriTest extends TestCase
         $this->uri->withQuery($query);
     }
 
+    public function testPercentageEncodedWillNotBeReEncoded(): void
+    {
+        $uri = new Uri('https://us%40er:pa%23ss@example.com/pa<th/to/tar>get/?qu^ery=str|ing#frag%ment');
+        $this->assertSame(
+            'https://us%40er:pa%23ss@example.com/pa%3Cth/to/tar%3Eget/?qu%5Eery=str%7Cing#frag%25ment',
+            (string) $uri,
+        );
+
+        $newUri = new Uri((string) $uri);
+        $this->assertSame((string) $uri, (string) $newUri);
+
+        $uri = (new Uri($path = '/pa%3C%3Eth'))->withPath($path);
+        $this->assertSame($path, $uri->getPath());
+
+        $uri = (new Uri('?' . $query = 'que%3C%3Ery=str%7Cing'))->withQuery($query);
+        $this->assertSame($query, $uri->getQuery());
+
+        $uri = (new Uri('#' . $fragment = 'frag%3C%3Ement'))->withFragment($fragment);
+        $this->assertSame($fragment, $uri->getFragment());
+    }
+
     public function testUtf8Host(): void
     {
         $uri = new Uri('https://ουτοπία.δπθ.gr/');
@@ -463,27 +484,6 @@ final class UriTest extends TestCase
         // "A" is a Latin letter
         $uri = (new Uri())->withHost('яндекAс.рф');
         $this->assertSame('яндекaс.рф', $uri->getHost());
-    }
-
-    public function testPercentageEncodedWillNotBeReEncoded(): void
-    {
-        $uri = new Uri('https://us%40er:pa%23ss@example.com/pa<th/to/tar>get/?qu^ery=str|ing#frag%ment');
-        $this->assertSame(
-            'https://us%40er:pa%23ss@example.com/pa%3Cth/to/tar%3Eget/?qu%5Eery=str%7Cing#frag%25ment',
-            (string) $uri,
-        );
-
-        $newUri = new Uri((string) $uri);
-        $this->assertSame((string) $uri, (string) $newUri);
-
-        $uri = (new Uri($path = '/pa%3C%3Eth'))->withPath($path);
-        $this->assertSame($path, $uri->getPath());
-
-        $uri = (new Uri('?' . $query = 'que%3C%3Ery=str%7Cing'))->withQuery($query);
-        $this->assertSame($query, $uri->getQuery());
-
-        $uri = (new Uri('#' . $fragment = 'frag%3C%3Ement'))->withFragment($fragment);
-        $this->assertSame($fragment, $uri->getFragment());
     }
 
     public function testIPv6Host(): void


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| Breaks BC?    | no

This solution is more predictable compared to the `strtolower()` function.

The `strtolower()` function may incorrectly handle some characters, this is especially actual for use in Windows OS.

The `mb_strtolower()` function requires the installation of an extension https://www.php.net/manual/en/mbstring.installation.php.